### PR TITLE
Add Fcarbon command which shows Carbon in configurable a floating window

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Some main features that NetRW offers which Carbon.nvim does not:
 
 Some main features that Carbon.nvim offers which NetRW does not:
 
+- Has a [floating window mode](#fcarbon)
 - Automatically reflects changes to the file system in the buffer
 - Compresses deeply nested child paths like GitHub does, but even better!
-  (See `:h carbon-setting-compress` for more information).
+  (See `:h carbon-setting-compress` for more information)
 
 If Carbon.nvim looks like it's for you then feel free to continue
 to the [Installation](#installation) section!
@@ -114,19 +115,34 @@ customization options.
 
 #### Carbon / Explore
 
-![Carbon / Explore command example](/doc/assets/carbon-explore.gif)
+Command: `:Carbon`
+Alias: `:Explore`
 
 The `:Carbon` command replaces the current buffer with a Carbon buffer.
 When `:h carbon-setting-keep-netrw` is `false` then NetRW's `:Explore`
 command is aliased to `:Carbon`.
 
+![Carbon / Explore command example](/doc/assets/carbon-explore.gif)
+
 #### Lcarbon / Lexplore
 
-![Lcarbon / Lexplore command example](/doc/assets/carbon-lexplore.gif)
+Command: `:Lcarbon`
+Alias: `:Lexplore`
 
 The `:Lcarbon` command opens a Carbon buffer in a split to the left of the
 current buffer. When `:h carbon-setting-keep-netrw` is `false` then NetRW's
 `:Lexplore` command is aliased to `:Lcarbon`.
+
+![Lcarbon / Lexplore command example](/doc/assets/carbon-lexplore.gif)
+
+#### Fcarbon
+
+Command: `:Fcarbon`
+
+The `:Fcarbon` command opens a Carbon buffer in a floating window. This
+window can be configured using `:h carbon-setting-float-settings`.
+
+![Fcarbon command example](/doc/assets/carbon-fexplore.gif)
 
 ### Mappings
 

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -97,6 +97,26 @@ COMMANDS                                                         *carbon-command
   way, pressing the key mapped to |carbon-plug-edit| will open files in a
   split directly to the right.
 
+  `------------------------------------------------------------------------------`
+  Fcarbon                                                                *Fcarbon*
+
+  Implementation: `:lua require('carbon').explore_float()`
+
+  Opens the Carbon buffer in a floating window. When Carbon is opened this
+  way, Carbon will open files the following way:
+
+  |carbon-plug-edit| will close the floating Carbon window and open the file in
+  the current window.
+
+  |carbon-plug-split| will close the floating Carbon window and open the file
+  in a split relative to the current window.
+
+  |carbon-plug-vsplit| will close the floating Carbon window and open the file
+  in a vertical split relative to the current window.
+
+  See |carbon-setting-float-settings| for more information on how to configure
+  the floating window spawned by `:Fcarbon`.
+
 ================================================================================
 PLUGS                                                               *carbon-plugs*
 
@@ -142,7 +162,7 @@ PLUGS                                                               *carbon-plug
 
   If the entry below the cursor is a directory, expands or collapses the
   directory. Otherwise the file is opened in the current window unless the
-  |Lcarbon| command was used.
+  |Lcarbon| or |Fcarbon| command was used.
 
   `------------------------------------------------------------------------------`
   <plug>(carbon-split)                                         *carbon-plug-split*
@@ -151,7 +171,8 @@ PLUGS                                                               *carbon-plug
   Mapping:        |carbon-setting-actions-split|
 
   Opens the entry below the cursor in a new |split| if it is a file. If the
-  entry is a directory then nothing happens.
+  entry is a directory then nothing happens. When Carbon was opened with
+  |Fcarbon| this works slightly different. See |Fcarbon| for more information.
 
   `------------------------------------------------------------------------------`
   <plug>(carbon-vsplit)                                       *carbon-plug-vsplit*
@@ -160,7 +181,8 @@ PLUGS                                                               *carbon-plug
   Mapping:        |carbon-setting-actions-vsplit|
 
   Opens the entry below the cursor in a new |vsplit| if it is a file. If the
-  entry is a directory then nothing happens.
+  entry is a directory then nothing happens. When Carbon was opened with
+  |Fcarbon| this works slightly different. See |Fcarbon| for more information.
 
 ================================================================================
 CARBON                                                             *carbon-carbon*
@@ -1085,6 +1107,41 @@ SETTINGS                                                         *carbon-setting
   more than one character is allowed. This setting may be set to `nil` to
   disable indicators. Individual indicators can also be disabled by setting
   them to `nil`.
+
+  `------------------------------------------------------------------------------`
+  float_settings                                   *carbon-setting-float-settings*
+
+  Default:
+    `function()`
+      `local columns = vim.opt.columns:get()`
+      `local rows = vim.opt.lines:get()`
+      `local width = math.min(50, columns * 0.8)`
+      `local height = math.min(20, rows * 0.8)`
+
+      `return {`
+        `relative = 'editor',`
+        `style = 'minimal',`
+        `border = 'single',`
+        `width = width,`
+        `height = height,`
+        `col = math.floor(columns / 2 - width / 2),`
+        `row = math.floor(rows / 2 - height / 2 - 2),`
+      `}`
+    `end`
+
+  This setting controls the window settings used in floating windows spawned
+  via |Fcarbon|. When set to a table, this table will be passed to
+  |nvim_open_window| directly.
+
+  When set to a function, the function will be executed and its return value
+  must be a table which will then be passed to |nvim_open_window|. The function
+  form allows you to specify the size based on the current dimensions of the
+  editor which is not possible when passing a table directly!
+
+  The default function will create a horizontally and vertically centered
+  popup with a maximum width of 80% up to 50 columns and maximum height of 80%
+  up to 20 lines. All dimensions and offsets will be based on the current
+  dimensions of the editor when this function is called.
 
   `------------------------------------------------------------------------------`
   actions                                                 *carbon-setting-actions*

--- a/lua/carbon.lua
+++ b/lua/carbon.lua
@@ -23,6 +23,7 @@ function carbon.initialize()
 
   util.command('Carbon', carbon.explore)
   util.command('Lcarbon', carbon.explore_left)
+  util.command('Fcarbon', carbon.explore_float)
 
   util.map(util.plug('up'), carbon.up)
   util.map(util.plug('down'), carbon.down)
@@ -38,7 +39,8 @@ function carbon.initialize()
           \ setlocal fillchars& fillchars=eob:\ |
           \ autocmd BufHidden <buffer>
               \ setlocal nowrap& fillchars& |
-              \ let w:carbon_lexplore_window = v:false
+              \ let w:carbon_lexplore_window = v:false |
+              \ let w:carbon_fexplore_window = v:false |
     augroup END
   ]])
 
@@ -93,6 +95,10 @@ function carbon.edit()
       vim.cmd('edit ' .. entry.path)
     end
   else
+    if vim.w.carbon_fexplore_window then
+      vim.api.nvim_win_close(0, 1)
+    end
+
     vim.cmd('edit ' .. entry.path)
   end
 end
@@ -101,6 +107,10 @@ function carbon.split()
   local entry = buffer.cursor().entry
 
   if not entry.is_directory then
+    if vim.w.carbon_fexplore_window then
+      vim.api.nvim_win_close(0, 1)
+    end
+
     vim.cmd('split ' .. entry.path)
   end
 end
@@ -109,6 +119,10 @@ function carbon.vsplit()
   local entry = buffer.cursor().entry
 
   if not entry.is_directory then
+    if vim.w.carbon_fexplore_window then
+      vim.api.nvim_win_close(0, 1)
+    end
+
     vim.cmd('vsplit ' .. entry.path)
   end
 end
@@ -123,6 +137,27 @@ function carbon.explore_left()
   buffer.show()
 
   vim.w.carbon_lexplore_window = vim.api.nvim_get_current_win()
+end
+
+function carbon.explore_float()
+  local carbon_fexplore_window = vim.api.nvim_get_current_win()
+  local window = vim.api.nvim_open_win(buffer.handle(), 1, {
+    relative = 'editor',
+    style = 'minimal',
+    border = 'single',
+    width = 50,
+    height = 20,
+    row = math.floor(vim.opt.lines:get() / 2 - 20 / 2 - 2),
+    col = math.floor(vim.opt.columns:get() / 2 - 50 / 2),
+  })
+
+  vim.api.nvim_win_set_option(
+    window,
+    'winhl',
+    'FloatBorder:Normal,Normal:Normal'
+  )
+
+  vim.w.carbon_fexplore_window = carbon_fexplore_window
 end
 
 function carbon.up()

--- a/lua/carbon.lua
+++ b/lua/carbon.lua
@@ -140,16 +140,14 @@ function carbon.explore_left()
 end
 
 function carbon.explore_float()
+  local window_settings = settings.float_settings
+
+  if type(window_settings) == 'function' then
+    window_settings = window_settings()
+  end
+
   local carbon_fexplore_window = vim.api.nvim_get_current_win()
-  local window = vim.api.nvim_open_win(buffer.handle(), 1, {
-    relative = 'editor',
-    style = 'minimal',
-    border = 'single',
-    width = 50,
-    height = 20,
-    row = math.floor(vim.opt.lines:get() / 2 - 20 / 2 - 2),
-    col = math.floor(vim.opt.columns:get() / 2 - 50 / 2),
-  })
+  local window = vim.api.nvim_open_win(buffer.handle(), 1, window_settings)
 
   vim.api.nvim_win_set_option(
     window,

--- a/lua/carbon/settings.lua
+++ b/lua/carbon/settings.lua
@@ -24,6 +24,22 @@ return {
     expand = '+',
     collapse = '-',
   },
+  float_settings = function()
+    local columns = vim.opt.columns:get()
+    local rows = vim.opt.lines:get()
+    local width = math.min(50, columns * 0.8)
+    local height = math.min(20, rows * 0.8)
+
+    return {
+      relative = 'editor',
+      style = 'minimal',
+      border = 'single',
+      width = width,
+      height = height,
+      col = math.floor(columns / 2 - width / 2),
+      row = math.floor(rows / 2 - height / 2 - 2),
+    }
+  end,
   actions = {
     up = '[',
     down = ']',


### PR DESCRIPTION
This PR resolves #1 by adding a new [`Fcarbon`](https://github.com/SidOfc/carbon.nvim#fcarbon) command which will spawn a floating window. Configuration settings for this floating window have been placed under `:h carbon-setting-float-settings`.