### PR TITLE
Reduce synchronization to parent directories of changed paths

### DIFF
--- a/lua/carbon/entry.lua
+++ b/lua/carbon/entry.lua
@@ -69,7 +69,11 @@ function entry.find(path)
 end
 
 function entry:synchronize()
-  if self.is_directory then
+  if not self.is_directory then
+    return
+  end
+
+  if vim.fn.isdirectory(self.path) == 1 then
     local current_paths = {}
     local previous_children = data.children[self.path] or {}
     data.children[self.path] = nil
@@ -98,6 +102,8 @@ function entry:synchronize()
         child:terminate()
       end
     end
+  else
+    self:terminate()
   end
 end
 


### PR DESCRIPTION
Whenever any file is modified within (including) Carbon's root directory the current root is synchronized. This PR changes synchronization to only synchronize parent directories of modified paths.

This means that making file modifications in subfolders will not trigger a `synchronize` for unrelated parent and sibling directories. However, sibling folders of the changed path will still be synchronized.

Further optimization from this could be to modify Carbon `buffer.process_event` to pass not only parent directory path but also changed filename. Then sibling folders could also be excluded.