### PR TITLE
Patch: nvim 0.7

### DIFF
--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -518,14 +518,6 @@ UTIL                                                                 *carbon-uti
   mapping pass `buffer = <bufnr>` where `<bufnr>` is a |bufnr()|.
 
   `------------------------------------------------------------------------------`
-  indexed_callback                                  *carbon-util-indexed-callback*
-
-  Signature: `require('carbon.util').indexed_callback(`{index}`)`
-
-  Calls the function stored at {index}. The |carbon-util-map| method uses this
-  method to be able to accept callback functions.
-
-  `------------------------------------------------------------------------------`
   command                                                    *carbon-util-command*
 
   Signature: `require('carbon.util').command(`{lhs}, {rhs}[, {options}]`)`

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -131,9 +131,10 @@ AUTOCMDS                                                         *carbon-autocmd
 
   Group:          `Carbon`
   Event:          `BufEnter`
-  Pattern:        `carbon`
+  Pattern:
   Implementation: `lua require('carbon.buffer').process_enter()`
 
+  Local to Carbon buffers.
   Calls |carbon-buffer-process-enter| when entering a Carbon buffer.
 
   `------------------------------------------------------------------------------`
@@ -141,9 +142,10 @@ AUTOCMDS                                                         *carbon-autocmd
 
   Group:          `Carbon`
   Event:          `BufHidden`
-  Pattern:        `carbon`
+  Pattern:
   Implementation: `lua require('carbon.buffer').process_hidden()`
 
+  Local to Carbon buffers.
   Calls |carbon-buffer-process-hidden| when the Carbon buffer is hidden.
 
   `------------------------------------------------------------------------------`
@@ -151,9 +153,10 @@ AUTOCMDS                                                         *carbon-autocmd
 
   Group:          `Carbon`
   Event:          `CursorMovedI`
-  Pattern:        `carbon`
+  Pattern:
   Implementation: `lua require('carbon.buffer').process_insert_move()`
 
+  Local to Carbon buffers.
   Calls |carbon-buffer-process-insert-move| when moving the cursor in insert mode.
   Used during |carbon-buffer-create| to control the line and minimul column
   offset of the cursor.
@@ -581,15 +584,14 @@ UTIL                                                                 *carbon-uti
   `------------------------------------------------------------------------------`
   autocmd                                                    *carbon-util-autocmd*
 
-  Signature: `require('carbon.util').autocmd(`{group}, {event}, {aupat}, {rhs}`)`
+  Signature: `require('carbon.util').autocmd(`{event}, {cmd_or_cb}[, {opts}]`)`
 
-  Defines an |autocmd| for {event} and {aupat} which executes {rhs}. The
-  autocommand is wrapped in an |augroup| named {group}.
+  Wraps |nvim_create_autocmd|. Sets {opts}`.callback` to {cmd_or_cb} before
+  being passed to |nvim_create_autocmd|.
 
-  {group} must be a string containing the name of the augroup.
-  {event} must be a string containing the name of the autocommand.
-  {aupat} must be a string |autocmd-pattern|.
-  {rhs} must be a vim command string or a function.
+  The {opts}.`group` option will default to `'Carbon'` if not specified.
+
+  Returns the `id` returned by |nvim_create_autocmd|.
 
   For more information about which autocommands Carbon uses,
   see |carbon-autocmds|.
@@ -643,9 +645,6 @@ UTIL                                                                 *carbon-uti
 
   Each {event} = {rhs} key-value pair must be valid in |carbon-util-autocmd|.
   The remaining arguments of |carbon-util-autocmd| are automatically set to:
-
-  {group} => `'CarbonBuffer'`
-  {aupat} => `'<buffer=' ..` {buf} `.. '>'`
 
   {buf} must be a valid |bufnr|.
   {autocmds} must be a table.

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -556,17 +556,12 @@ UTIL                                                                 *carbon-uti
 
   Signature: `require('carbon.util').command(`{lhs}, {rhs}[, {options}]`)`
 
-  Wraps |nvim_add_user_command| if possible. The only difference between this
+  Wraps |nvim_add_user_command|. The only difference between this
   function and |nvim_add_user_command| is that the {options} argument is
   optional, when not passed it will default to an empty table.
 
-  When |nvim_add_user_command| is not available this method falls back
-  to |vim.cmd| to create the command. The {options} argument is ignored when
-  this happens. It is still possible to pass functions even when
-  |nvim_add_user_command| is not available.
-
   {lhs} must be a string containing the key name for this |user-command|.
-  {rhs} must be a vim command string or a function.
+  {rhs} must be a vim command string or a lua callback.
   {options} must be a table if supplied.
 
   `------------------------------------------------------------------------------`

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -569,7 +569,7 @@ UTIL                                                                 *carbon-uti
 
   Signature: `require('carbon.util').highlight(`{group}, {properties}`)`
 
-  Defines a |highlight|for {group} using provided {properties} and executes that
+  Defines a |highlight| for {group} using provided {properties} and executes that
   command. {group} will be the highlight group name. {properties} is a table
   accepting any properties that can be passed to |highlight|.
 

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -508,40 +508,14 @@ UTIL                                                                 *carbon-uti
   otherwise in {options}.
 
   {lhs} must be a string containing the key for this mapping.
-  {rhs} must be a vim command string or a function.
+  {rhs} must be a vim command string or a lua callback.
   {options} must be a table if supplied.
 
-  When a function is passed to {rhs}, it is pushed to a table local to the
-  util module. The {rhs} is then replaced with a sequence which calls
-  |carbon-util-indexed-callback| with the correct index. For example:
-
-  `require('carbon.util').map(`"n", function() print("hello") end`)`
-
-  Will map the key `"n"` to:
-
-  `:<c-u>lua require("carbon.util").indexed_callback(1)<cr>`
+  When a function is passed to {rhs} `options.callback` will be set to
+  {rhs} and {rhs} will be set to an empty string.
 
   To create a |visual-mode| mapping pass `mode = 'v'`, to create a buffer-local
   mapping pass `buffer = <bufnr>` where `<bufnr>` is a |bufnr()|.
-
-  An arbitrary prefix string may be supplied via the option `rhs_prefix`. This
-  string will be prepended to {rhs}. This allows lua functions to be used in
-  more places, such as |insert-mode|, because you can prepend `'<esc>'` to leave
-  insert mode before the bound callback is executed. For example:
-
-  `require('carbon.util').map(`
-    "i",
-    function() print("hello") end,
-    { rhs_prefix = '<esc>' }
-  `)`
-
-  Will map the key `"n"` to:
-
-  `<esc>:<c-u>lua require("carbon.util").indexed_callback(1)<cr>`
-
-  The `mode`, `buffer` and `rhs_prefix` options are not passed to |nvim_set_keymap|
-  functions because they are explicitly filtered out for internal use by the
-  map utility function. All other {options} keys will be passed through.
 
   `------------------------------------------------------------------------------`
   indexed_callback                                  *carbon-util-indexed-callback*

--- a/lua/carbon.lua
+++ b/lua/carbon.lua
@@ -35,12 +35,8 @@ function carbon.initialize()
   util.map(util.plug('delete'), carbon.delete)
   util.map(util.plug('quit'), carbon.quit)
 
-  util.autocmd('Carbon', 'BufEnter', 'carbon', buffer.process_enter)
-  util.autocmd('Carbon', 'BufHidden', 'carbon', buffer.process_hidden)
-  util.autocmd('Carbon', 'CursorMovedI', 'carbon', buffer.process_insert_move)
-
   if settings.sync_on_cd then
-    util.autocmd('Carbon', 'DirChanged', 'global', carbon.cd)
+    util.autocmd('DirChanged', carbon.cd, { pattern = 'global' })
   end
 
   if type(settings.highlights) == 'table' then
@@ -173,7 +169,9 @@ function carbon.down()
 end
 
 function carbon.cd(path)
-  if buffer.cd(path or vim.v.event.cwd) then
+  local destination = path and path.file or path or vim.v.event.cwd
+
+  if buffer.cd(destination) then
     vim.fn.cursor(1, 1)
     buffer.render()
   end

--- a/lua/carbon/buffer.lua
+++ b/lua/carbon/buffer.lua
@@ -29,8 +29,8 @@ function buffer.handle()
 
   local mappings = {
     { 'i', '<nop>' },
-    { '<cr>', buffer.create_confirm, { mode = 'i', rhs_prefix = '<esc>' } },
-    { '<esc>', buffer.create_cancel, { mode = 'i', rhs_prefix = '<esc>' } },
+    { '<cr>', buffer.create_confirm, { mode = 'i' } },
+    { '<esc>', buffer.create_cancel, { mode = 'i' } },
   }
 
   for action, mapping in pairs(settings.actions or {}) do
@@ -429,6 +429,7 @@ function buffer.create()
 end
 
 function buffer.create_confirm()
+  vim.cmd('stopinsert')
   local text = vim.fn.trim(vim.fn.getline('.'))
   local name = vim.fn.fnamemodify(text, ':t')
   local parent_directory = data.line_entry.path
@@ -447,6 +448,7 @@ function buffer.create_confirm()
 end
 
 function buffer.create_cancel()
+  vim.cmd('stopinsert')
   data.line_entry:set_open(data.prev_open)
   buffer.create_reset()
 end

--- a/lua/carbon/buffer.lua
+++ b/lua/carbon/buffer.lua
@@ -48,6 +48,10 @@ function buffer.handle()
     modified = false,
     bufhidden = 'hide',
     mappings = mappings,
+    autocmds = {
+      BufEnter = buffer.process_enter,
+      BufHidden = buffer.process_hidden,
+    },
   })
 
   return data.handle
@@ -413,6 +417,11 @@ function buffer.create()
 
   data.reset_jump = { lnum = line.lnum, col = 1 }
   data.cursor_bounds = { lnum = edit_lnum + 1, col = #edit_indent + 1 }
+  data.insert_move_autocmd = util.autocmd(
+    'CursorMovedI',
+    buffer.process_insert_move,
+    { buffer = handle }
+  )
 
   vim.fn.cursor(edit_lnum + 1, #edit_indent)
   vim.api.nvim_buf_set_option(handle, 'modifiable', true)
@@ -446,6 +455,7 @@ function buffer.create_reset()
   local handle = buffer.handle()
   local lnum = vim.fn.line('.')
 
+  vim.api.nvim_del_autocmd(data.insert_move_autocmd)
   vim.api.nvim_buf_set_lines(handle, lnum - 1, lnum, 1, {})
   vim.api.nvim_buf_set_option(handle, 'modifiable', false)
   vim.api.nvim_buf_set_option(handle, 'modified', false)
@@ -457,6 +467,7 @@ function buffer.create_reset()
   data.reset_jump = nil
   data.cursor_bounds = nil
   data.prev_compressible = nil
+  data.insert_move_autocmd = nil
 
   buffer.render()
 end

--- a/lua/carbon/settings.lua
+++ b/lua/carbon/settings.lua
@@ -50,7 +50,7 @@ return {
     vsplit = '<c-v>',
     create = 'c',
     delete = 'd',
-    quit = { 'q', '<esc>' },
+    quit = 'q',
   },
   highlights = {
     CarbonDir = {

--- a/lua/carbon/util.lua
+++ b/lua/carbon/util.lua
@@ -103,17 +103,7 @@ function util.autocmd(event, cmd_or_callback, opts)
 end
 
 function util.command(lhs, rhs, options)
-  if not vim.api.nvim_add_user_command then
-    if type(rhs) == 'function' then
-      rhs = ':lua require("carbon.util").indexed_callback('
-        .. index_callback(rhs)
-        .. ')'
-    end
-
-    vim.cmd('command! ' .. lhs .. ' ' .. rhs)
-  else
-    vim.api.nvim_add_user_command(lhs, rhs, options or {})
-  end
+  return vim.api.nvim_create_user_command(lhs, rhs, options or {})
 end
 
 function util.highlight(group, properties)

--- a/lua/carbon/util.lua
+++ b/lua/carbon/util.lua
@@ -70,16 +70,14 @@ end
 
 function util.map(lhs, rhs, settings_param)
   local settings = settings_param or {}
-  local options = util.tbl_except(settings, { 'mode', 'buffer', 'rhs_prefix' })
+  local options = util.tbl_except(settings, { 'mode', 'buffer' })
   local mode = settings.mode or 'n'
 
   if type(rhs) == 'function' then
-    rhs = ':<c-u>lua require("carbon.util").indexed_callback('
-      .. index_callback(rhs)
-      .. ')<cr>'
+    options.callback = rhs
+    rhs = ''
   end
 
-  rhs = (settings.rhs_prefix or '') .. rhs
   options = util.tbl_merge(
     { silent = true, nowait = true, noremap = true },
     options

--- a/lua/carbon/util.lua
+++ b/lua/carbon/util.lua
@@ -1,19 +1,5 @@
 local util = {}
-
-local function index_callback(callback)
-  local found, index = util.tbl_find(data.indexed_callbacks, function(other)
-    return other == callback
-  end)
-
-  if not found then
-    index = #data.indexed_callbacks + 1
-    data.indexed_callbacks[index] = callback
-  end
-
-  return index
-end
 local data = {
-  indexed_callbacks = {},
   guicursors = {},
   augroup = vim.api.nvim_create_augroup('Carbon', { clear = false }),
 }
@@ -60,12 +46,6 @@ function util.tbl_except(tbl, keys)
   end
 
   return settings
-end
-
-function util.indexed_callback(index, ...)
-  if type(data.indexed_callbacks[index]) == 'function' then
-    return data.indexed_callbacks[index](...)
-  end
 end
 
 function util.map(lhs, rhs, settings_param)


### PR DESCRIPTION
Use Lua api support for callbacks exclusively for utilities such as `util.map`, `util.command`, and `util.autocmd`. The old implementation used a hacky indexed method cache which never got cleared. While the side effects of this memory leak are barely noticeable it makes little sense to support this behaviour now that it is completely avoidable :)