### PR TITLE
patch/watch and sync

### DIFF
--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -854,20 +854,6 @@ ENTRY                                                               *carbon-entr
   For more information about entry objects, see: |carbon-entry-new|.
 
   `------------------------------------------------------------------------------`
-  clean                                                       *carbon-entry-clean*
-
-  Signature: `require('carbon.entry').clean(`{path}`)`
-
-  Removes all parent and sibling files and directories from the internal
-  children cache used by Carbon. Also removes watchers from all removed
-  children using |carbon-watcher-release|.
-
-  WARNING:
-  It is not recommended to call this method manually because it
-  has a high likelyhood of breaking Carbon if not used with caution. It is
-  only documented for completeness.
-
-  `------------------------------------------------------------------------------`
   synchronize                                           *carbon-entry-synchronize*
 
   Signature: `entry:synchronize()`
@@ -1719,13 +1705,14 @@ WATCHER                                                           *carbon-watche
   which support some shortcuts.
 
   `------------------------------------------------------------------------------`
-  clear                                                     *carbon-watcher-clear*
+  keep                                                       *carbon-watcher-keep*
 
-  Signature: `require('carbon.watcher').clear()`
+  Signature: `require('carbon.watcher').keep(`{callback}`)`
 
-  This method calls |carbon-watcher-release| on all paths registered using
-  |carbon-watcher-register|. This unregisters all the paths but leaves the
-  callbacks intact.
+  Calls {callback} for each `path` which is currently being listened to.
+  When {callback} returns `true` for a `path`, it will be kept.
+  Otherwise, when `false` is returned |carbon-watcher-release| will be
+  called with `path`.
 
   `------------------------------------------------------------------------------`
   release                                                 *carbon-watcher-release*

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -483,6 +483,14 @@ UTIL                                                                 *carbon-uti
   external to Carbon.
 
   `------------------------------------------------------------------------------`
+  is_excluded                                            *carbon-util-is-excluded*
+
+  Signature: `require('carbon.util').is_excluded(`{path}`)`
+
+  Returns `true` if given {path} matches any |carbon-setting-exclude|.
+  Will not be called when |carbon-settings-exclude| is set to `nil` or `false`.
+
+  `------------------------------------------------------------------------------`
   cursor                                                      *carbon-util-cursor*
 
   Signature: `require('carbon.util').cursor(`{row}, {col}`)`

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -856,25 +856,35 @@ ENTRY                                                               *carbon-entr
   `------------------------------------------------------------------------------`
   synchronize                                           *carbon-entry-synchronize*
 
-  Signature: `entry:synchronize()`
+  Signature: `entry:synchronize(`{paths}`)`
 
   The variable `entry` in this section refers to an entry object as returned by
   the |carbon-entry-new| method.
 
-  When `entry.is_directory` is `false`, nothing happens because Carbon only
-  listens to changes to and within directories.
+  Returns `nil` when `entry.is_directory` is `false`.
 
-  When `entry.is_directory` is `true` and |isdirectory| of `entry.path` is `1`,
-  synchronizes all its children with the current state of the file system
-  recursively. Files and folders that were added, removed, renamed, or had
-  their permissions changed within `entry.path` will be refreshed.
+  When `entry.path` is not an existing key in the {paths} table and
+  `entry:has_children()` is true, calls |carbon-entry-synchronize| on each
+  child in `entry:children()`.
 
-  When `entry.is_directory` is `true` and |isdirectory| of `entry.path` is `0`
-  then |carbon-entry-terminate| is called.
+  When `entry.path` is an existing key in the {paths} table the previous
+  children will be compared with the current children.
 
-  The method |carbon-watcher-release| will be called with the `path` of each
-  entry that will be removed. New entries will automatically call
-  |carbon-watcher-register| in |carbon-entry-new|.
+  This is done by collecting a list of unique paths from both previous and
+  current children and then looping over each. Each unique path may have a
+  `previous` and a `current` version. The following rules are then applied:
+
+  1. When both `previous` and `current` are available and `current.is_directory`
+     is `true` then |carbon-entry-set-open| is called on `current` with the value
+     of |carbon-entry-is-open| of `previous` and finally `entry:synchronize(`{paths}`)`
+     is called.
+
+  2. When `previous` exists but `current` does not then
+     |carbon-entry-terminate| is called on `previous`.
+
+  3. When `current` exists but `previous` does not then nothing happens. The
+     `current` entry is already an active child and `previous` has already
+     been terminated.
 
   `------------------------------------------------------------------------------`
   terminate                                               *carbon-entry-terminate*

--- a/lua/carbon/buffer.lua
+++ b/lua/carbon/buffer.lua
@@ -351,7 +351,10 @@ function buffer.set_root(target)
   end
 
   data.root = target
-  entry.clean(data.root.path)
+
+  watcher.keep(function(path)
+    return vim.startswith(path, data.root.path)
+  end)
 
   if settings.sync_pwd then
     vim.api.nvim_set_current_dir(data.root.path)

--- a/lua/carbon/buffer.lua
+++ b/lua/carbon/buffer.lua
@@ -282,31 +282,10 @@ function buffer.lines(input_target, lines, depth)
 end
 
 function buffer.synchronize()
-  local paths = vim.tbl_keys(data.resync_paths)
-  data.resync_paths = {}
-
-  table.sort(paths, function(a, b)
-    return #a < #b
-  end)
-
-  for idx = #paths, 1, -1 do
-    local path = paths[idx]
-    local found_path = util.tbl_find(paths, function(other)
-      return path ~= other and vim.startswith(path, other)
-    end)
-
-    if not found_path then
-      local found_entry = entry.find(path)
-
-      if found_entry then
-        found_entry:synchronize()
-      elseif path == data.root.path then
-        data.root:synchronize()
-      end
-    end
-  end
-
+  data.root:synchronize(data.resync_paths)
   buffer.render()
+
+  data.resync_paths = {}
 end
 
 function buffer.up(count)

--- a/lua/carbon/buffer.lua
+++ b/lua/carbon/buffer.lua
@@ -1,5 +1,6 @@
 local util = require('carbon.util')
 local entry = require('carbon.entry')
+local watcher = require('carbon.watcher')
 local settings = require('carbon.settings')
 local buffer = {}
 local internal = {}
@@ -185,6 +186,8 @@ function buffer.lines(input_target, lines, depth)
       highlights = { { 'CarbonDir', 0, -1 } },
       path = {},
     }
+
+    watcher.register(data.root.path)
   end
 
   for _, child in ipairs(target:children()) do
@@ -203,12 +206,16 @@ function buffer.lines(input_target, lines, depth)
         and #tmp:children() == 1
         and tmp:is_compressible()
       do
+        watcher.register(tmp.path)
+
         path[#path + 1] = tmp
         tmp = tmp:children()[1]
       end
     end
 
     if tmp.is_directory then
+      watcher.register(tmp.path)
+
       is_empty = #tmp:children() == 0
       path_suffix = '/'
 

--- a/lua/carbon/entry.lua
+++ b/lua/carbon/entry.lua
@@ -25,8 +25,6 @@ function entry.new(path, parent)
 
   if is_symlink and not select(2, pcall(vim.loop.fs_stat, clean)) then
     is_symlink = 2
-  elseif is_directory then
-    watcher.register(clean)
   end
 
   return setmetatable({

--- a/lua/carbon/entry.lua
+++ b/lua/carbon/entry.lua
@@ -1,6 +1,5 @@
 local util = require('carbon.util')
 local watcher = require('carbon.watcher')
-local settings = require('carbon.settings')
 local entry = {}
 local data = { children = {}, open = {}, compressible = {} }
 
@@ -168,21 +167,10 @@ function entry:get_children()
   local entries = {}
 
   for name in vim.fs.dir(self.path) do
-    local is_included = true
     local absolute_path = self.path .. '/' .. name
     local relative_path = vim.fn.fnamemodify(absolute_path, ':.')
 
-    if settings.exclude then
-      for _, pattern in ipairs(settings.exclude) do
-        if string.find(relative_path, pattern) then
-          is_included = false
-
-          break
-        end
-      end
-    end
-
-    if is_included then
+    if not util.is_excluded(relative_path) then
       entries[#entries + 1] = entry.new(absolute_path, self)
     end
   end

--- a/lua/carbon/entry.lua
+++ b/lua/carbon/entry.lua
@@ -47,35 +47,37 @@ function entry.find(path)
   end
 end
 
-function entry:synchronize(resync_paths)
+function entry:synchronize(paths)
   if not self.is_directory then
     return
   end
 
-  if resync_paths[self.path] then
+  if paths[self.path] then
+    local all_paths = {}
+    local current_paths = {}
+    local previous_paths = {}
     local previous_children = data.children[self.path] or {}
-    local paths = { all = {}, previous = {}, current = {} }
 
     self:set_children(nil)
 
     for _, previous in ipairs(previous_children) do
-      paths.all[previous.path] = true
-      paths.previous[previous.path] = previous
+      all_paths[previous.path] = true
+      previous_paths[previous.path] = previous
     end
 
     for _, current in ipairs(self:children()) do
-      paths.all[current.path] = true
-      paths.current[current.path] = current
+      all_paths[current.path] = true
+      current_paths[current.path] = current
     end
 
-    for path in pairs(paths.all) do
-      local previous = paths.previous[path]
-      local current = paths.current[path]
+    for path in pairs(all_paths) do
+      local current = current_paths[path]
+      local previous = previous_paths[path]
 
       if previous and current then
         if current.is_directory then
           current:set_open(previous:is_open())
-          current:synchronize(resync_paths)
+          current:synchronize(paths)
         end
       elseif previous then
         previous:terminate()
@@ -84,7 +86,7 @@ function entry:synchronize(resync_paths)
   elseif self:has_children() then
     for _, child in ipairs(self:children()) do
       if child.is_directory then
-        child:synchronize(resync_paths)
+        child:synchronize(paths)
       end
     end
   end

--- a/lua/carbon/entry.lua
+++ b/lua/carbon/entry.lua
@@ -39,22 +39,6 @@ function entry.new(path, parent)
   }, entry)
 end
 
-function entry.clean(path)
-  for parent_path, children in pairs(data.children) do
-    if not vim.startswith(parent_path, path) then
-      watcher.release(parent_path)
-
-      for _, child in ipairs(children) do
-        watcher.release(child.path)
-      end
-
-      data.children[parent_path] = nil
-    end
-  end
-
-  watcher.register(path)
-end
-
 function entry.find(path)
   for _, children in pairs(data.children) do
     for _, child in ipairs(children) do

--- a/lua/carbon/util.lua
+++ b/lua/carbon/util.lua
@@ -1,7 +1,18 @@
+local settings = require('carbon.settings')
 local util = {}
 local data = {
   augroup = vim.api.nvim_create_augroup('Carbon', { clear = false }),
 }
+
+function util.is_excluded(path)
+  if settings.exclude then
+    for _, pattern in ipairs(settings.exclude) do
+      if string.find(path, pattern) then
+        return true
+      end
+    end
+  end
+end
 
 function util.cursor(row, col)
   return vim.api.nvim_win_set_cursor(0, { row, col })
@@ -173,7 +184,7 @@ end
 function util.create_scratch_buf(options)
   options = options or {}
   local buf = vim.api.nvim_create_buf(false, true)
-  local settings = vim.tbl_extend('force', {
+  local buffer_options = vim.tbl_extend('force', {
     bufhidden = 'wipe',
     buftype = 'nofile',
     swapfile = false,
@@ -196,7 +207,7 @@ function util.create_scratch_buf(options)
     util.set_buf_autocmds(buf, options.autocmds)
   end
 
-  for option, value in pairs(settings) do
+  for option, value in pairs(buffer_options) do
     vim.api.nvim_buf_set_option(buf, option, value)
   end
 

--- a/lua/carbon/watcher.lua
+++ b/lua/carbon/watcher.lua
@@ -4,9 +4,11 @@ local data = {
   events = { change = {}, rename = {}, ['change-and-rename'] = {} },
 }
 
-function watcher.clear()
+function watcher.keep(callback)
   for path in pairs(data.listeners) do
-    watcher.release(path)
+    if not callback(path) then
+      watcher.release(path)
+    end
   end
 end
 

--- a/lua/carbon/watcher.lua
+++ b/lua/carbon/watcher.lua
@@ -1,3 +1,4 @@
+local util = require('carbon.util')
 local watcher = {}
 local data = {
   listeners = {},
@@ -21,23 +22,23 @@ function watcher.release(path)
 end
 
 function watcher.register(path)
-  watcher.release(path)
+  if not data.listeners[path] and not util.is_excluded(path) then
+    data.listeners[path] = vim.loop.new_fs_event()
 
-  data.listeners[path] = vim.loop.new_fs_event()
-
-  data.listeners[path]:start(
-    path,
-    {},
-    vim.schedule_wrap(function(error, filename, status)
-      if status.change and status.rename then
-        watcher.emit('change-and-rename', path, filename, error)
-      elseif status.change then
-        watcher.emit('change', path, filename, error)
-      elseif status.rename then
-        watcher.emit('rename', path, filename, error)
-      end
-    end)
-  )
+    data.listeners[path]:start(
+      path,
+      {},
+      vim.schedule_wrap(function(error, filename, status)
+        if status.change and status.rename then
+          watcher.emit('change-and-rename', path, filename, error)
+        elseif status.change then
+          watcher.emit('change', path, filename, error)
+        elseif status.rename then
+          watcher.emit('rename', path, filename, error)
+        end
+      end)
+    )
+  end
 end
 
 function watcher.emit(event, ...)


### PR DESCRIPTION
- Add `util.is_excluded` method
- Remove `entry.clean`, refactor `watcher.clear` into `watcher.keep` to simplify releasing watchers
- Make `watcher.register` a bit smarter, this surely fixes some naaaaaaasty memory leaks
- Move registering entries from `entry.new` to `buffer.lines` for more control
- Simplify `buffer:synchronize`, refactor `entry:synchronize` - do not half bake twice if you can full bake once
- Rename `entry:synchronize` argument to match documentation name
