### PR TITLE
Fix make some color groups more protable

### DIFF
--- a/lua/carbon/settings.lua
+++ b/lua/carbon/settings.lua
@@ -60,8 +60,8 @@ local defaults = {
     toggle_recursive = '!',
   },
   highlights = {
-    CarbonDir = { fg = '#00aaff', ctermfg = 'DarkBlue', bold = true },
-    CarbonFile = { fg = '#f8f8f8', ctermfg = 'LightGray', bold = true },
+    CarbonDir = { link = 'Directory' },
+    CarbonFile = { link = 'Text' },
     CarbonExe = { fg = '#22cc22', ctermfg = 'Green', bold = true },
     CarbonSymlink = { fg = '#d77ee0', ctermfg = 'Magenta', bold = true },
     CarbonBrokenSymlink = { fg = '#ea871e', ctermfg = 'Brown', bold = true },


### PR DESCRIPTION
When you first open Carbon the colors are very alien in respect of your
colorscheme. While some highlights should be supported by the colorschemes, I
think having a more 'portable' setup is best, meaning that should look resanobly
correct even in colorschemes that do not support Carbon's highlight group.
