### PR TITLE
feature/explore right

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Does nothing when on a directory. Edit a file in a new vertical split. See
 ### <kbd>q</kbd> Close a Carbon buffer
 
 Close a Carbon buffer, useful for closing Carbon buffers which were
-opened with [`Fcarbon`](#fcarbon) or [`Lcarbon`](#lcarbon--lexplore).
+opened with [`Fcarbon`](#fcarbon) or [`Lcarbon` / `Rcarbon`](#lcarbon--lexplore--rcarbon--rexplore).
 
 ![Close Carbon buffer example](/doc/assets/carbon-quit.gif)
 

--- a/README.md
+++ b/README.md
@@ -123,12 +123,16 @@ command is aliased to `:Carbon`.
 
 ![Carbon / Explore command example](/doc/assets/carbon-explore.gif)
 
-### `:Lcarbon` / `:Lexplore`
+### `:Lcarbon` / `:Lexplore` / `:Rcarbon` / `':Rexplore`
 
-The `:Lcarbon` command opens a Carbon buffer in a split to the left of the
-current buffer. When `:h carbon-setting-keep-netrw` is `false` then NetRW's
-`:Lexplore` command is aliased to `:Lcarbon`. Subsequent calls to `:Lcarbon`
-will attempt to navigate to an existing window opened via `:Lcarbon`.
+The `:Lcarbon` and `:Rcarbon` commands open a Carbon buffer in a vertical split
+left of the current buffer. When `:h carbon-setting-keep-netrw` is `false` then
+commands `Lexplore` and `Rexplore` are aliased to `Lcarbon` and `Rcarbon`
+respectively. Subsequent calls to `:Lcarbon` / `Rcarbon`
+will attempt to navigate to an existing window opened via these commands.
+
+Additionally, there is a command called `ToggleSidebarCarbon` which
+opens the sidebar to the side determined by `settings.sidebar_position`.
 
 ![Lcarbon / Lexplore command example](/doc/assets/carbon-lexplore.gif)
 

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -2101,7 +2101,7 @@ SETTINGS                                                         *carbon-setting
 
   Default: `true`
 
-  Whether or not to focus `:Lcarbon` window opened via `:ToggleLcarbon`.
+  Whether or not to focus sidebar windows opened via `:ToggleSidebarCarbon`.
 
   `------------------------------------------------------------------------------`
   sidebar_position                               *carbon-setting-sidebar-position*

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -1931,6 +1931,7 @@ SETTINGS                                                         *carbon-setting
   `  sync_delay           = `|carbon-setting-sync-delay|`,`
   `  sidebar_width        = `|carbon-setting-sidebar-width|`,`
   `  sidebar_toggle_focus = `|carbon-setting-sidebar-toggle-focus|`,`
+  `  sidebar_position     = `|carbon-setting-sidebar-position|`,`
   `  always_reveal        = `|carbon-setting-always-reveal|`,`
   `  exclude              = `|carbon-setting-exclude|`,`
 
@@ -2085,6 +2086,13 @@ SETTINGS                                                         *carbon-setting
   Default: `true`
 
   Whether or not to focus `:Lcarbon` window opened via `:ToggleLcarbon`.
+
+  `------------------------------------------------------------------------------`
+  sidebar_position                               *carbon-setting-sidebar-position*
+
+  Default: `'left'`
+
+  Default sidebar position, see |carbon-carbon-explore-sidebar| for context.
 
   `------------------------------------------------------------------------------`
   always_reveal                                     *carbon-setting-always-reveal*

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -144,15 +144,24 @@ COMMANDS                                                         *carbon-command
   |carbon-buffer-flash-bang| it if possible. This also works for its alias.
 
   `------------------------------------------------------------------------------`
-  ToggleLcarbon                                     *carbon-command-ToggleLcarbon*
+  Rcarbon                                                 *carbon-command-Rcarbon*
 
-  Implementation: `require('carbon').toggle_left()`
-  Alias:          `ToggleLexplore` unless |carbon-setting-keep-netrw| is enabled.
+  Implementation: `require('carbon').explore_right()`
+  Alias:          `Rexplore` unless |carbon-setting-keep-netrw| is enabled.
 
-  Calls |carbon-carbon-explore-left| if no `:Lcarbon` window exists. Otherwise
-  the existing `:Lcarbon` window will be closed.
+  Like |carbon-command-Lcarbon| but on the right side.
 
-  When a new `:Lcarbon` window is spawned it is also focussed automatically.
+  `------------------------------------------------------------------------------`
+  ToggleSidebarCarbon                         *carbon-command-ToggleSidebarCarbon*
+
+  Implementation: `require('carbon').toggle_sidebar()`
+  Alias:          `ToggleSidebarExplore` unless |carbon-setting-keep-netrw|
+                  is enabled.
+
+  Calls |carbon-carbon-explore-sidebar| if no sidebar window exists. Otherwise
+  the existing sidebar window will be closed.
+
+  When a new sidebar window is spawned it is also focussed automatically.
   This behavior can be disabled by setting |carbon-setting-sidebar-toggle-focus|
   to `false`.
 
@@ -421,9 +430,10 @@ CARBON                                                             *carbon-carbo
 
   If the entry which the cursor is on is a directory then this method expands
   or collapses it depending on its current state. If it is a file and the
-  current buffer was opened using |carbon-carbon-explore-left| then the file will
-  be opened in a new split to the right. A split will be created if it does not
-  exist. Otherwise if it is a file it will be edited in the current window.
+  current buffer was opened using |carbon-carbon-explore-sidebar| then the file
+  will be opened in a new split. A split will be created if it does not exist.
+
+  When this fails the file will be edited in the current window instead.
 
   `------------------------------------------------------------------------------`
   split                                                      *carbon-carbon-split*
@@ -456,13 +466,20 @@ CARBON                                                             *carbon-carbo
   the current buffer.
 
   `------------------------------------------------------------------------------`
-  explore_left                                        *carbon-carbon-explore-left*
+  explore_sidebar                                  *carbon-carbon-explore-sidebar*
 
-  Signature: `require('carbon').explore_left(`[{options}]`)`
+  Signature: `require('carbon').explore_sidebar(`[{options}]`)`
 
-  Show Carbon in a new vertical split on the left side with a width of
-  |carbon-setting-sidebar-width|. Used by the |carbon-command-Lcarbon| command and
-  modifies how |carbon-carbon-edit| works for that window.
+  Show Carbon in a new vertical split with a width of
+  |carbon-setting-sidebar-width|. Used by the |carbon-command-Lcarbon| and
+  |carbon-command-Rcarbon| commands and modifies how |carbon-carbon-edit| works
+  for that window.
+
+  Currently, the position can either be `'left'` or `'right'`.
+  The position of the sidebar is resolved in following order:
+  1. `options.position`
+  2. `settings.sidebar_position`
+  3. `'left'`
 
   When {options} is given and `options.bang` is `true` or when
   |carbon-setting-always-reveal| is `true` then this calls
@@ -473,12 +490,12 @@ CARBON                                                             *carbon-carbo
   window opened via `:Lcarbon`.
 
   `------------------------------------------------------------------------------`
-  toggle_left                                          *carbon-carbon-toggle-left*
+  toggle_sidebar                                    *carbon-carbon-toggle-sidebar*
 
-  Signature: `require('carbon').toggle_left(`[{options}]`)`
+  Signature: `require('carbon').toggle_sidebar(`[{options}]`)`
 
-  When an `:Lcarbon` window exists, it will be closed, otherwise
-  |carbon-carbon-explore-left| will be called and the new `:LCarbon` window
+  When a sidebar window exists, it will be closed, otherwise
+  |carbon-carbon-explore-sidebar| will be called and the new sidebar window
   will be focussed automatically.
 
   This automatic focus switch can be disabled by setting
@@ -1139,11 +1156,13 @@ BUFFER                                                             *carbon-buffe
   directory Neovim was opened with, or set to an arbitrary path.
 
   `------------------------------------------------------------------------------`
-  lexplore_window_id                            *carbon-buffer-lexplore-window-id*
+  sidebar_window_id                              *carbon-buffer-sidebar-window-id*
 
-  Signature: `require('carbon.buffer').lexplore_window_id()`
+  Signature: `require('carbon.buffer').sidebar_window_id()`
 
-  Returns the |winid| of the window opened by |carbon-command-Lcarbon|.
+  Returns the |winid| of the window opened by |carbon-command-Lcarbon|,
+  |carbon-command-Rcarbon|, or |carbon-command-ToggleSidebarCarbon|.
+
   Returns `nil` when no such window exists.
 
   `------------------------------------------------------------------------------`
@@ -1239,9 +1258,8 @@ BUFFER                                                             *carbon-buffe
   This method restores |fillchars| and |wrap| back to their original values
   before |carbon-buffer-process-enter| was called.
 
-  It also `nils` out both `vim.w.carbon_lexplore_window` and
-  `vim.w.carbon_fexplore_window` window-local variables which are used internally
-  by |carbon-command-Lcarbon| and |carbon-command-Fcarbon| respectively.
+  It also `nils` out any `vim.w.carbon_*` window-local variables which are used
+  internally by some of Carbon's commands.
 
   `------------------------------------------------------------------------------`
   is_loaded                                              *carbon-buffer-is-loaded*

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -478,7 +478,7 @@ CARBON                                                             *carbon-carbo
   Currently, the position can either be `'left'` or `'right'`.
   The position of the sidebar is resolved in following order:
   1. `options.position`
-  2. `settings.sidebar_position`
+  2. |carbon-setting-sidebar-position|
   3. `'left'`
 
   When {options} is given and `options.bang` is `true` or when
@@ -488,6 +488,22 @@ CARBON                                                             *carbon-carbo
 
   Subsequent calls to `:Lcarbon` will attempt to navigate to an existing
   window opened via `:Lcarbon`.
+
+  `------------------------------------------------------------------------------`
+  explore_left                                        *carbon-carbon-explore-left*
+
+  Signature: `require('carbon').explore_left(`[{options}]`)`
+
+  Calls |carbon-carbon-explore-sidebar| with `options.position` set to `'left'`.
+  All other options are passed through as-is.
+
+  `------------------------------------------------------------------------------`
+  explore_right                                      *carbon-carbon-explore-right*
+
+  Signature: `require('carbon').explore_right(`[{options}]`)`
+
+  Calls |carbon-carbon-explore-sidebar| with `options.position` set to `'right'`.
+  All other options are passed through as-is.
 
   `------------------------------------------------------------------------------`
   toggle_sidebar                                    *carbon-carbon-toggle-sidebar*

--- a/lua/carbon/buffer.lua
+++ b/lua/carbon/buffer.lua
@@ -62,11 +62,11 @@ function buffer.handle()
   return data.handle
 end
 
-function buffer.lexplore_window_id()
+function buffer.sidebar_window_id()
   local existing_win
 
   for _, win in ipairs(vim.api.nvim_list_wins()) do
-    if pcall(vim.api.nvim_win_get_var, win, 'carbon_lexplore_window') then
+    if pcall(vim.api.nvim_win_get_var, win, 'carbon_sidebar_window') then
       if vim.api.nvim_win_is_valid(win) then
         existing_win = win
       end
@@ -76,6 +76,14 @@ function buffer.lexplore_window_id()
   end
 
   return existing_win
+end
+
+function buffer.sidebar_window_split()
+  local existing_win = buffer.sidebar_window_id()
+
+  if existing_win then
+    return vim.api.nvim_win_get_var(existing_win, 'carbon_sidebar_split')
+  end
 end
 
 function buffer.show()
@@ -613,7 +621,8 @@ function buffer.process_hidden()
   vim.opt_local.wrap = vim.opt_global.wrap:get()
   vim.opt_local.spell = vim.opt_global.spell:get()
   vim.opt_local.fillchars = vim.opt_global.fillchars:get()
-  vim.w.carbon_lexplore_window = nil
+  vim.w.carbon_sidebar_split = nil
+  vim.w.carbon_sidebar_window = nil
   vim.w.carbon_fexplore_window = nil
 end
 

--- a/lua/carbon/settings.lua
+++ b/lua/carbon/settings.lua
@@ -7,6 +7,7 @@ local defaults = {
   sync_delay = 20,
   sidebar_width = 30,
   sidebar_toggle_focus = true,
+  sidebar_position = 'left',
   always_reveal = false,
   exclude = {
     '~$',

--- a/test/specs/carbon_spec.lua
+++ b/test/specs/carbon_spec.lua
@@ -12,6 +12,7 @@ describe('carbon', function()
   before_each(function()
     carbon.explore()
     util.cursor(1, 1)
+    vim.cmd.only()
   end)
 
   describe('autocommands', function()
@@ -190,20 +191,23 @@ describe('carbon', function()
     end)
   end)
 
-  describe('explore_left', function()
-    it('shows the buffer to the left of the current buffer', function()
-      util.cursor(12, 1)
-      carbon.edit()
+  describe('explore_sidebar', function()
+    it(
+      'shows the buffer to the left of the current buffer by default',
+      function()
+        util.cursor(12, 1)
+        carbon.edit()
 
-      local before_bufname = vim.fn.bufname()
+        local before_bufname = vim.fn.bufname()
 
-      carbon.explore_left()
-      vim.cmd.wincmd('l')
+        carbon.explore_sidebar()
+        vim.cmd.wincmd('l')
 
-      assert.equal(before_bufname, vim.fn.bufname())
+        assert.equal(before_bufname, vim.fn.bufname())
 
-      vim.cmd.bdelete()
-    end)
+        vim.cmd.bdelete()
+      end
+    )
   end)
 
   describe('explore_float', function()

--- a/test/specs/carbon_spec.lua
+++ b/test/specs/carbon_spec.lua
@@ -210,6 +210,38 @@ describe('carbon', function()
     )
   end)
 
+  describe('explore_right', function()
+    it('opens on the right side', function()
+      util.cursor(12, 1)
+      carbon.edit()
+
+      local before_bufname = vim.fn.bufname()
+
+      carbon.explore_right()
+      vim.cmd.wincmd('h')
+
+      assert.equal(before_bufname, vim.fn.bufname())
+
+      vim.cmd.bdelete()
+    end)
+  end)
+
+  describe('explore_left', function()
+    it('opens on the left side', function()
+      util.cursor(12, 1)
+      carbon.edit()
+
+      local before_bufname = vim.fn.bufname()
+
+      carbon.explore_left()
+      vim.cmd.wincmd('l')
+
+      assert.equal(before_bufname, vim.fn.bufname())
+
+      vim.cmd.bdelete()
+    end)
+  end)
+
   describe('explore_float', function()
     it('shows the buffer in a floating window', function()
       carbon.explore_float()


### PR DESCRIPTION
- Implement `Rcarbon`, rename `ToggleLexplore` to `ToggleSidebarCarbon`. (#111)
- Document `settings.sidebar_position`
- Document and test explore_left and explore_right
- Fix changed command name
- Update README.md
