### PR TITLE
Schedule the carbon initialization on lazy init...

### DIFF
--- a/lua/carbon.lua
+++ b/lua/carbon.lua
@@ -26,7 +26,7 @@ function carbon.setup(user_settings)
   end
 
   if vim.g.carbon_lazy_init ~= nil then
-    carbon.initialize()
+    vim.schedule(carbon.initialize)
   end
 
   return settings


### PR DESCRIPTION
This enables the initialization to safely wait until any textlocks close.

See what you think. This works on my box but may not be ideomatic for the codebase. :)