### PR TITLE
Add possibility to customize float border

### DIFF
--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -2492,7 +2492,7 @@ SETTINGS                                                         *carbon-setting
     `    ctermbg = 'Black',`
     `  },`
     `  CarbonFloatBorder = {`          *carbon-setting-highlights-CarbonFloatBorder*
-    `    link = 'FloatBorder',`
+    `    link = 'CarbonFloat',`
     `  },`
     `  CarbonDanger = {`                    *carbon-setting-highlights-CarbonDanger*
     `    link = 'Error',`

--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -2487,9 +2487,12 @@ SETTINGS                                                         *carbon-setting
     `    ctermfg = 'DarkGray',`
     `    bold = true,`
     `  },`
-    `  CarbonFloat = {`                       *carbon-setting-highlights-CarbonFloat*
+    `  CarbonFloat = {`                      *carbon-setting-highlights-CarbonFloat*
     `    bg = '#111111',`
     `    ctermbg = 'Black',`
+    `  },`
+    `  CarbonFloatBorder = {`          *carbon-setting-highlights-CarbonFloatBorder*
+    `    link = 'FloatBorder',`
     `  },`
     `  CarbonDanger = {`                    *carbon-setting-highlights-CarbonDanger*
     `    link = 'Error',`

--- a/lua/carbon/settings.lua
+++ b/lua/carbon/settings.lua
@@ -72,6 +72,7 @@ local defaults = {
     CarbonBrokenSymlink = { link = 'DiagnosticError' },
     CarbonIndicator = { fg = 'Gray', ctermfg = 'DarkGray', bold = true },
     CarbonFloat = { bg = '#111111', ctermbg = 'black' },
+    CarbonFloatBorder = { link = 'FloatBorder' },
     CarbonDanger = { link = 'Error' },
     CarbonPending = { link = 'Search' },
     CarbonFlash = { link = 'Visual' },

--- a/lua/carbon/settings.lua
+++ b/lua/carbon/settings.lua
@@ -72,7 +72,7 @@ local defaults = {
     CarbonBrokenSymlink = { link = 'DiagnosticError' },
     CarbonIndicator = { fg = 'Gray', ctermfg = 'DarkGray', bold = true },
     CarbonFloat = { bg = '#111111', ctermbg = 'black' },
-    CarbonFloatBorder = { link = 'FloatBorder' },
+    CarbonFloatBorder = { link = 'CarbonFloat' },
     CarbonDanger = { link = 'Error' },
     CarbonPending = { link = 'Search' },
     CarbonFlash = { link = 'Visual' },

--- a/lua/carbon/view.lua
+++ b/lua/carbon/view.lua
@@ -149,7 +149,7 @@ function view.activate(options_param)
     vim.api.nvim_win_set_option(
       view.float.origin,
       'winhl',
-      'FloatBorder:CarbonFloat,Normal:CarbonFloat'
+      'FloatBorder:CarbonFloatBorder,Normal:CarbonFloat'
     )
   else
     vim.api.nvim_win_set_buf(0, current_view:buffer())


### PR DESCRIPTION
This pull request adds the `CarbonFloatBorder` highlight group to allow customization of the floating explorer window's border