### PR TITLE
Fix: do not store entries for non-existent folders

### DIFF
--- a/lua/carbon/entry.lua
+++ b/lua/carbon/entry.lua
@@ -152,6 +152,8 @@ function entry:get_children()
     end
 
     table.sort(entries)
+  else
+    return nil
   end
 
   return entries

--- a/test/specs/entry_spec.lua
+++ b/test/specs/entry_spec.lua
@@ -228,5 +228,15 @@ describe('carbon.entry', function()
 
       helpers.delete_path('a/')
     end)
+
+    it('does not set children on a non-existing directory', function()
+      helpers.ensure_path('a/b/c.txt')
+
+      local dir = entry.new(helpers.resolve('a/doesnotexit/'))
+      
+      assert.is_nil(dir:get_children())
+
+      helpers.delete_path('a/')
+    end)
   end)
 end)


### PR DESCRIPTION
Repro:
```
edit .
call input('hit enter')
echomsg 'create inital folder'
!mkdir -p hello/ && touch hello/a && touch hello/b
echomsg 'created inital folder'
edit hello/
echomsg 'opened hello'
call input('hit enter')
echomsg 'deleting folder'
!rm -rf hello/
echomsg 'deleted folder'
call input('hit enter')
echomsg 'creating folder'
!mkdir -p hello/ && touch hello/a && touch hello/b
echomsg 'created folder folder'
call input('hit enter')
```

When running the above script, one ends up with the folder `hello` permanently empty in every carbon view. Despite the folder having children on the disk.

Fixed by distinguishing an empty folder from a non-existent folder in `entry:get_children`. A failure from `fs_scandir` is otherwise indistinguishable from an empty but existing folder.