### PR TITLE
test(watcher): Fix flaky `carbon:synchronize` tests

### DIFF
--- a/test/config/helpers.lua
+++ b/test/config/helpers.lua
@@ -53,6 +53,16 @@ function helpers.ensure_path(relative_path)
   end
 end
 
+function helpers.poll_spy_calls(spy, call_count, timeout, interval, fast_only)
+  timeout = math.max(0, timeout or 3000)
+  call_count = math.max(0, call_count or 1)
+  interval = interval or math.max(10, timeout / 100)
+
+  vim.wait(timeout, function()
+    return #spy.calls >= call_count
+  end, interval, fast_only)
+end
+
 function helpers.type_keys(keys_to_type)
   return vim.api.nvim_feedkeys(
     vim.api.nvim_replace_termcodes(keys_to_type, true, false, true),

--- a/test/specs/watcher_spec.lua
+++ b/test/specs/watcher_spec.lua
@@ -50,7 +50,7 @@ describe('carbon.watcher', function()
         watcher.on('carbon:synchronize', callback)
 
         helpers.ensure_path('check.txt')
-        vim.wait(100)
+        helpers.poll_spy_calls(callback, 1)
 
         assert
           .spy(callback).was
@@ -66,7 +66,7 @@ describe('carbon.watcher', function()
         watcher.on('carbon:synchronize', callback)
 
         helpers.change_file('check.sh')
-        vim.wait(100)
+        helpers.poll_spy_calls(callback, 1)
 
         assert.spy(callback).was.called(1)
         assert
@@ -83,7 +83,7 @@ describe('carbon.watcher', function()
         watcher.on('carbon:synchronize', callback)
 
         helpers.delete_path('check.sh')
-        vim.wait(100)
+        helpers.poll_spy_calls(callback, 1)
 
         assert.spy(callback).was.called(1)
         assert


### PR DESCRIPTION
Fixed tests which sometimes failed due to naive use of `vim.wait(100)`
