### PR TITLE
refactor: Rename `vim.loop` to `vim.uv`

### DIFF
--- a/doc/carbon.txt
+++ b/doc/carbon.txt
@@ -728,7 +728,7 @@ UTIL                                                                 *carbon-uti
 
   Signature: `require('carbon.util').is_directory(`{path}`)`
 
-  Uses the `type` attribute returned by `fs_stat` from `vim.loop` to determine
+  Uses the `type` attribute returned by `fs_stat` from `vim.uv` to determine
   whether given {path} is a directory. Returns a boolean value or `nil` if the
   call to `fs_stat` failed.
 
@@ -2093,8 +2093,8 @@ WATCHER                                                           *carbon-watche
 
   Usage: `require('carbon.watcher')`
 
-  This module provides a thin wrapper around `vim.loop.new_fs_event`, see
-  |watch-file| for more information about `vim.loop.new_fs_event`. Paths can
+  This module provides a thin wrapper around `vim.uv.new_fs_event`, see
+  |watch-file| for more information about `vim.uv.new_fs_event`. Paths can
   be registered using |carbon-watcher-register|, once registered, any change
   to that path will cause an event to be emitted. Registered paths can be
   released using |carbon-watcher-release|. Releasing a path will stop the
@@ -2211,7 +2211,7 @@ WATCHER                                                           *carbon-watche
   Signature: `require('carbon.watcher').register(`{path}`)`
 
   Register an absolute {path}. Once registered, any changes made to this path
-  will emit events based on events received from Neovim's Lua |vim.loop| api.
+  will emit events based on events received from Neovim's Lua |vim.uv| api.
 
   See |carbon-watcher-built-in-events| for a list of built-in events.
 

--- a/lua/carbon/entry.lua
+++ b/lua/carbon/entry.lua
@@ -18,13 +18,13 @@ end
 function entry.new(path, parent)
   local raw_path = path == '' and '/' or path
   local clean = string.gsub(raw_path, '/+$', '')
-  local lstat = select(2, pcall(vim.loop.fs_lstat, raw_path)) or {}
+  local lstat = select(2, pcall(vim.uv.fs_lstat, raw_path)) or {}
   local is_executable = false
   local is_directory = lstat.type == 'directory'
   local is_symlink = lstat.type == 'link' and 1
 
   if is_symlink then
-    local ok, stat = pcall(vim.loop.fs_stat, raw_path)
+    local ok, stat = pcall(vim.uv.fs_stat, raw_path)
 
     if ok and stat then
       is_directory = stat.type == 'directory'
@@ -145,11 +145,11 @@ end
 
 function entry:get_children()
   local entries = {}
-  local handle = vim.loop.fs_scandir(self.raw_path)
+  local handle = vim.uv.fs_scandir(self.raw_path)
 
   if type(handle) == 'userdata' then
     local function iterator()
-      return vim.loop.fs_scandir_next(handle)
+      return vim.uv.fs_scandir_next(handle)
     end
 
     for name in iterator do

--- a/lua/carbon/init.lua
+++ b/lua/carbon/init.lua
@@ -26,7 +26,7 @@ function carbon.setup(user_settings)
     end
 
     local argv = vim.fn.argv()
-    local open = argv[1] and vim.fn.fnamemodify(argv[1], ':p') or vim.loop.cwd()
+    local open = argv[1] and vim.fn.fnamemodify(argv[1], ':p') or vim.uv.cwd()
     local command_opts = { bang = true, nargs = '?', complete = 'dir' }
 
     watcher.on('carbon:synchronize', function(_, path)

--- a/lua/carbon/util.lua
+++ b/lua/carbon/util.lua
@@ -10,11 +10,11 @@ function util.explore_path(path, current_view)
   path = string.gsub(path, '%s', '')
 
   if path == '' then
-    path = vim.loop.cwd() or ''
+    path = vim.uv.cwd() or ''
   end
 
   if not vim.startswith(path, '/') then
-    local base_path = current_view and current_view.root.path or vim.loop.cwd()
+    local base_path = current_view and current_view.root.path or vim.uv.cwd()
 
     path = string.format('%s/%s', base_path, path)
   end
@@ -47,7 +47,7 @@ function util.cursor(row, col)
 end
 
 function util.is_directory(path)
-  return (vim.loop.fs_stat(path) or {}).type == 'directory'
+  return (vim.uv.fs_stat(path) or {}).type == 'directory'
 end
 
 function util.plug(name)

--- a/lua/carbon/view.lua
+++ b/lua/carbon/view.lua
@@ -115,7 +115,7 @@ function view.activate(options_param)
   local original_window = vim.api.nvim_get_current_win()
   local current_view = (options.path and view.get(options.path))
     or view.current()
-    or view.get(vim.loop.cwd())
+    or view.get(vim.uv.cwd())
 
   if options.reveal or settings.auto_reveal then
     current_view:expand_to_path(vim.fn.expand('%'))
@@ -539,7 +539,7 @@ end
 
 function view:set_root(target, options_param)
   local options = options_param or {}
-  local is_cwd = self.root.path == vim.loop.cwd()
+  local is_cwd = self.root.path == vim.uv.cwd()
 
   if type(target) == 'string' then
     target = entry.new(target)
@@ -959,7 +959,7 @@ function view:move()
 
   if updated_path == ctx.target.path then
     self:render()
-  elseif vim.loop.fs_stat(updated_path) then
+  elseif vim.uv.fs_stat(updated_path) then
     self:render()
     vim.api.nvim_echo({
       { 'Failed to move: ', 'CarbonDanger' },
@@ -1008,7 +1008,7 @@ function view:switch_to_existing_view(path)
   if destination_view then
     vim.api.nvim_win_set_buf(0, destination_view:buffer())
 
-    if settings.sync_pwd and self.root.path == vim.loop.cwd() then
+    if settings.sync_pwd and self.root.path == vim.uv.cwd() then
       vim.api.nvim_set_current_dir(destination_view.root.path)
     end
 

--- a/lua/carbon/watcher.lua
+++ b/lua/carbon/watcher.lua
@@ -25,7 +25,7 @@ end
 
 function watcher.register(path)
   if not watcher.listeners[path] then
-    watcher.listeners[path] = vim.loop.new_fs_event()
+    watcher.listeners[path] = vim.uv.new_fs_event()
 
     watcher.listeners[path]:start(
       path,

--- a/test/config/bootstrap.lua
+++ b/test/config/bootstrap.lua
@@ -1,4 +1,4 @@
-vim.env.CARBON_REPO_ROOT = vim.loop.cwd()
+vim.env.CARBON_REPO_ROOT = vim.uv.cwd()
 
 local test_options = { minimal_init = 'test/config/init.lua' }
 local plenary_repo = 'https://github.com/nvim-lua/plenary.nvim'

--- a/test/config/helpers.lua
+++ b/test/config/helpers.lua
@@ -20,7 +20,7 @@ end
 function helpers.resolve(relative_path)
   local clean_path = string.gsub(relative_path, '/+^', '')
 
-  return string.format('%s/%s', vim.loop.cwd(), clean_path)
+  return string.format('%s/%s', vim.uv.cwd(), clean_path)
 end
 
 function helpers.change_file(relative_path)
@@ -36,7 +36,7 @@ function helpers.delete_path(relative_path)
 end
 
 function helpers.has_path(relative_path)
-  return vim.loop.fs_stat(helpers.resolve(relative_path)) ~= nil
+  return vim.uv.fs_stat(helpers.resolve(relative_path)) ~= nil
 end
 
 function helpers.is_directory(relative_path)
@@ -88,7 +88,7 @@ function helpers.autocmd(event, options)
 end
 
 function helpers.entry(relative_path)
-  return entry.find(string.format('%s/%s', vim.loop.cwd(), relative_path))
+  return entry.find(string.format('%s/%s', vim.uv.cwd(), relative_path))
 end
 
 function helpers.is_open(path)

--- a/test/config/init.lua
+++ b/test/config/init.lua
@@ -1,4 +1,4 @@
-local repo_root = vim.loop.cwd()
+local repo_root = vim.uv.cwd()
 local tmp_dir = vim.fn.tempname()
 
 vim.opt.runtimepath:prepend(repo_root)

--- a/test/specs/carbon_spec.lua
+++ b/test/specs/carbon_spec.lua
@@ -311,13 +311,13 @@ describe('carbon', function()
 
   describe('up', function()
     it('sets cwd to parent directory', function()
-      local original_cwd = vim.loop.cwd()
+      local original_cwd = vim.uv.cwd()
 
       settings.sync_pwd = true
       carbon.up()
 
       assert.is.equal(
-        vim.loop.cwd(),
+        vim.uv.cwd(),
         original_cwd and vim.fn.fnamemodify(original_cwd, ':h')
       )
 
@@ -336,42 +336,42 @@ describe('carbon', function()
 
   describe('reset', function()
     it('reset to original cwd during startup', function()
-      local original_cwd = vim.loop.cwd()
+      local original_cwd = vim.uv.cwd()
 
       settings.sync_pwd = true
       carbon.up()
       carbon.reset()
       settings.sync_pwd = settings.defaults.sync_pwd
 
-      assert.is.equal(original_cwd, vim.loop.cwd())
+      assert.is.equal(original_cwd, vim.uv.cwd())
     end)
   end)
 
   describe('down', function()
     it('sets cwd to cursor directory', function()
-      local original_cwd = vim.loop.cwd()
+      local original_cwd = vim.uv.cwd()
 
       settings.sync_pwd = true
       util.cursor(2, 1)
       carbon.down()
 
-      assert.is.equal(vim.loop.cwd(), string.format('%s/.github', original_cwd))
+      assert.is.equal(vim.uv.cwd(), string.format('%s/.github', original_cwd))
 
       carbon.reset()
-      assert.is.equal(vim.loop.cwd(), original_cwd)
+      assert.is.equal(vim.uv.cwd(), original_cwd)
       settings.sync_pwd = settings.defaults.sync_pwd
     end)
   end)
 
   describe('cd', function()
     it('sets cwd to target path', function()
-      local jump_cwd = string.format('%s/test/specs', vim.loop.cwd())
+      local jump_cwd = string.format('%s/test/specs', vim.uv.cwd())
 
       settings.sync_pwd = true
       util.cursor(2, 1)
       carbon.cd(jump_cwd)
 
-      assert.is.equal(jump_cwd, vim.loop.cwd())
+      assert.is.equal(jump_cwd, vim.uv.cwd())
 
       carbon.reset()
       settings.sync_pwd = settings.defaults.sync_pwd

--- a/test/specs/entry_spec.lua
+++ b/test/specs/entry_spec.lua
@@ -39,7 +39,7 @@ describe('carbon.entry', function()
       local original = helpers.resolve('README.md')
       local symlink = string.format('%s-symlink', original)
 
-      vim.loop.fs_symlink(original, symlink)
+      vim.uv.fs_symlink(original, symlink)
 
       assert.is.equal(1, entry.new(symlink).is_symlink)
 
@@ -51,7 +51,7 @@ describe('carbon.entry', function()
       local broken = string.format('%s-broken', original)
       local symlink = string.format('%s-symlink', original)
 
-      vim.loop.fs_symlink(broken, symlink)
+      vim.uv.fs_symlink(broken, symlink)
 
       assert.is.equal(2, entry.new(symlink).is_symlink)
 

--- a/test/specs/util_spec.lua
+++ b/test/specs/util_spec.lua
@@ -15,7 +15,7 @@ describe('carbon.util', function()
 
   describe('explore_path', function()
     it('{path} is expanded to an absolute path', function()
-      local cwd = vim.loop.cwd()
+      local cwd = vim.uv.cwd()
       local parent = cwd and vim.fn.fnamemodify(cwd, ':h')
 
       assert.is.equal(parent, util.explore_path('../'))
@@ -42,7 +42,7 @@ describe('carbon.util', function()
 
   describe('is_directory', function()
     it('returns true when {path} is a directory', function()
-      assert.is_true(util.is_directory(vim.loop.cwd()))
+      assert.is_true(util.is_directory(vim.uv.cwd()))
     end)
 
     it('returns false when {path} is a file', function()

--- a/test/specs/watcher_spec.lua
+++ b/test/specs/watcher_spec.lua
@@ -46,7 +46,7 @@ describe('carbon.watcher', function()
       it('triggers on new file', function()
         local callback = spy.new(function() end)
 
-        watcher.register(vim.loop.cwd())
+        watcher.register(vim.uv.cwd())
         watcher.on('carbon:synchronize', callback)
 
         helpers.ensure_path('check.txt')
@@ -54,7 +54,7 @@ describe('carbon.watcher', function()
 
         assert
           .spy(callback).was
-          .called_with('carbon:synchronize', vim.loop.cwd(), 'check.txt', nil)
+          .called_with('carbon:synchronize', vim.uv.cwd(), 'check.txt', nil)
       end)
 
       it('triggers on file change', function()
@@ -62,7 +62,7 @@ describe('carbon.watcher', function()
 
         helpers.ensure_path('check.sh')
 
-        watcher.register(vim.loop.cwd())
+        watcher.register(vim.uv.cwd())
         watcher.on('carbon:synchronize', callback)
 
         helpers.change_file('check.sh')
@@ -71,7 +71,7 @@ describe('carbon.watcher', function()
         assert.spy(callback).was.called(1)
         assert
           .spy(callback).was
-          .called_with('carbon:synchronize', vim.loop.cwd(), 'check.sh', nil)
+          .called_with('carbon:synchronize', vim.uv.cwd(), 'check.sh', nil)
       end)
 
       it('triggers on file remove', function()
@@ -79,7 +79,7 @@ describe('carbon.watcher', function()
 
         helpers.ensure_path('check.sh')
 
-        watcher.register(vim.loop.cwd())
+        watcher.register(vim.uv.cwd())
         watcher.on('carbon:synchronize', callback)
 
         helpers.delete_path('check.sh')
@@ -88,7 +88,7 @@ describe('carbon.watcher', function()
         assert.spy(callback).was.called(1)
         assert
           .spy(callback).was
-          .called_with('carbon:synchronize', vim.loop.cwd(), 'check.sh', nil)
+          .called_with('carbon:synchronize', vim.uv.cwd(), 'check.sh', nil)
       end)
     end)
   end)


### PR DESCRIPTION
Neovim supports `vim.uv` since version `0.10.0`
